### PR TITLE
Improve AA5 compatibility for optional integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Admin App status: users with `is_superuser` can now see the list of imported app
 
 I've opened an [issue](https://github.com/Maestro-Zacht/aa-charlink/issues/1) to track the apps that have a default integration in CharLink and the WIPs. If you want another app to be supported, please comment on the issue, reach me on the [AllianceAuth discord server](https://discord.gg/fjnHAmk) or ask the developer of the app to implement an [integration via hook](#hook-integration).
 
+CharLink supports Alliance Auth 4 and 5. Some optional integrations expose different ESI scope helper names across app versions; CharLink resolves those helpers by capability detection where needed. Optional integration import failures are reported in the CharLink admin status instead of breaking dashboard rendering.
+
 ## Hook integration
 
 From version 1.1.0, CharLink supports hook integration. If you want to integrate your app with CharLink, you need to register a hook in the `auth_hooks.py` file:

--- a/charlink/app_imports/__init__.py
+++ b/charlink/app_imports/__init__.py
@@ -43,8 +43,8 @@ def import_apps():
             except ModuleNotFoundError:
                 logger.debug(f"Loading of {hook_mod} link via hook: failed to import")
                 _failed_to_import[hook_mod] = _("Hook import: import not found")
-            except:
-                logger.debug(f"Loading of {hook_mod} link via hook: failed")
+            except Exception:
+                logger.debug(f"Loading of {hook_mod} link via hook: failed", exc_info=True)
                 _failed_to_import[hook_mod] = _("Hook import: generic error")
             else:
                 if app_import.app_label in _supported_apps:
@@ -60,13 +60,26 @@ def import_apps():
         # defaults
         for app in settings.INSTALLED_APPS:
             if app != 'allianceauth' and app not in _supported_apps:
+                module_name = f'charlink.imports.{app}'
                 try:
-                    module = import_module(f'charlink.imports.{app}')
-                except ModuleNotFoundError:
-                    logger.debug(f"Loading of {app} link: not found")
-                    _no_import.append(app)
+                    app_import: AppImport = import_module(module_name).app_import
+                    assert type(app_import) == AppImport
+                    app_import.validate_import()
+                except AssertionError:
+                    logger.debug(f"Loading of {app} link: failed to validate")
+                    _failed_to_import[app] = _("Default import: failed to validate")
+                except ModuleNotFoundError as e:
+                    if e.name == module_name or module_name.startswith(f'{e.name}.'):
+                        logger.debug(f"Loading of {app} link: not found")
+                        _no_import.append(app)
+                    else:
+                        logger.debug(f"Loading of {app} link: failed to import", exc_info=True)
+                        _failed_to_import[app] = _("Default import: import not found")
+                except Exception:
+                    logger.debug(f"Loading of {app} link: failed", exc_info=True)
+                    _failed_to_import[app] = _("Default import: generic error")
                 else:
-                    _supported_apps[app] = module.app_import
+                    _supported_apps[app] = app_import
                     logger.debug(f"Loading of {app} link: success")
 
         for app, app_import in _supported_apps.items():

--- a/charlink/imports/memberaudit.py
+++ b/charlink/imports/memberaudit.py
@@ -55,13 +55,19 @@ def _users_with_perms():
     return users_with_permissions('memberaudit.basic_access', require_all=False)
 
 
+def _character_esi_scopes():
+    if hasattr(Character, 'esi_scopes'):
+        return Character.esi_scopes()
+    return Character.get_esi_scopes()
+
+
 app_import = AppImport('memberaudit', [
     LoginImport(
         app_label='memberaudit',
         unique_id='default',
         field_label=MEMBERAUDIT_APP_NAME,
         add_character=_add_character,
-        scopes=Character.get_esi_scopes(),
+        scopes=_character_esi_scopes(),
         check_permissions=lambda user: user.has_perm("memberaudit.basic_access"),
         is_character_added=_is_character_added,
         is_character_added_annotation=Exists(

--- a/charlink/imports/structures.py
+++ b/charlink/imports/structures.py
@@ -118,13 +118,19 @@ def _users_with_perms():
     return users_with_permissions('structures.add_structure_owner', require_all=False)
 
 
+def _owner_esi_scopes():
+    if hasattr(Owner, 'esi_scopes'):
+        return Owner.esi_scopes()
+    return Owner.get_esi_scopes()
+
+
 app_import = AppImport('structures', [
     LoginImport(
         app_label='structures',
         unique_id='default',
         field_label=__title__,
         add_character=_add_character,
-        scopes=Owner.get_esi_scopes(),
+        scopes=_owner_esi_scopes(),
         check_permissions=lambda user: user.has_perm("structures.add_structure_owner"),
         is_character_added=_is_character_added,
         is_character_added_annotation=Exists(

--- a/charlink/tests/imports/test_memberaudit.py
+++ b/charlink/tests/imports/test_memberaudit.py
@@ -1,3 +1,93 @@
+from importlib import import_module
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+
+class _FakeQuery:
+    def clone(self):
+        return self
+
+    def exists(self):
+        return self
+
+
+class _FakeQuerySet:
+    query = _FakeQuery()
+
+
+class _FakeManager:
+    def filter(self, *args, **kwargs):
+        return _FakeQuerySet()
+
+    def exists(self):
+        return False
+
+
+class _FakeComplianceGroupDesignation:
+    objects = _FakeManager()
+
+
+def _load_memberaudit_import_scopes(character):
+    original_import = sys.modules.pop('charlink.imports.memberaudit', None)
+
+    memberaudit_module = ModuleType('memberaudit')
+    memberaudit_module.__path__ = []
+    memberaudit_module.tasks = SimpleNamespace(
+        update_character=SimpleNamespace(apply_async=lambda *args, **kwargs: None),
+        update_compliance_groups_for_user=SimpleNamespace(
+            apply_async=lambda *args, **kwargs: None
+        ),
+    )
+
+    memberaudit_models = ModuleType('memberaudit.models')
+    memberaudit_models.Character = character
+    memberaudit_models.ComplianceGroupDesignation = _FakeComplianceGroupDesignation
+
+    memberaudit_settings = ModuleType('memberaudit.app_settings')
+    memberaudit_settings.MEMBERAUDIT_APP_NAME = 'Member Audit'
+    memberaudit_settings.MEMBERAUDIT_TASKS_NORMAL_PRIORITY = 5
+
+    fake_modules = {
+        'memberaudit': memberaudit_module,
+        'memberaudit.models': memberaudit_models,
+        'memberaudit.app_settings': memberaudit_settings,
+    }
+
+    try:
+        with patch.dict(sys.modules, fake_modules):
+            memberaudit_import = import_module('charlink.imports.memberaudit')
+            return memberaudit_import.app_import.imports[0].scopes
+    finally:
+        sys.modules.pop('charlink.imports.memberaudit', None)
+        if original_import:
+            sys.modules['charlink.imports.memberaudit'] = original_import
+
+
+class TestMemberAuditScopes(SimpleTestCase):
+    def test_uses_esi_scopes_when_available(self):
+        class Character:
+            objects = _FakeManager()
+
+            @staticmethod
+            def esi_scopes():
+                return ['new_scope']
+
+        self.assertEqual(_load_memberaudit_import_scopes(Character), ['new_scope'])
+
+    def test_falls_back_to_get_esi_scopes(self):
+        class Character:
+            objects = _FakeManager()
+
+            @staticmethod
+            def get_esi_scopes():
+                return ['old_scope']
+
+        self.assertEqual(_load_memberaudit_import_scopes(Character), ['old_scope'])
+
+
 # from unittest.mock import patch
 
 # from django.test import TestCase, RequestFactory

--- a/charlink/tests/imports/test_structures.py
+++ b/charlink/tests/imports/test_structures.py
@@ -1,3 +1,89 @@
+from importlib import import_module
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+
+class _FakeQuery:
+    def clone(self):
+        return self
+
+    def exists(self):
+        return self
+
+
+class _FakeQuerySet:
+    query = _FakeQuery()
+
+
+class _FakeManager:
+    def filter(self, *args, **kwargs):
+        return _FakeQuerySet()
+
+
+class _FakeOwnerCharacter:
+    objects = _FakeManager()
+
+
+class _FakeWebhook:
+    objects = _FakeManager()
+
+
+def _load_structures_import_scopes(owner):
+    original_import = sys.modules.pop('charlink.imports.structures', None)
+
+    structures_module = ModuleType('structures')
+    structures_module.__path__ = []
+    structures_module.__title__ = 'Structures'
+    structures_module.tasks = SimpleNamespace(
+        update_all_for_owner=SimpleNamespace(delay=lambda *args, **kwargs: None)
+    )
+
+    structures_models = ModuleType('structures.models')
+    structures_models.Owner = owner
+    structures_models.OwnerCharacter = _FakeOwnerCharacter
+    structures_models.Webhook = _FakeWebhook
+
+    structures_settings = ModuleType('structures.app_settings')
+    structures_settings.STRUCTURES_ADMIN_NOTIFICATIONS_ENABLED = False
+    structures_settings.STRUCTURES_DEFAULT_LANGUAGE = 'en'
+
+    fake_modules = {
+        'structures': structures_module,
+        'structures.models': structures_models,
+        'structures.app_settings': structures_settings,
+    }
+
+    try:
+        with patch.dict(sys.modules, fake_modules):
+            structures_import = import_module('charlink.imports.structures')
+            return structures_import.app_import.imports[0].scopes
+    finally:
+        sys.modules.pop('charlink.imports.structures', None)
+        if original_import:
+            sys.modules['charlink.imports.structures'] = original_import
+
+
+class TestStructuresScopes(SimpleTestCase):
+    def test_uses_esi_scopes_when_available(self):
+        class Owner:
+            @staticmethod
+            def esi_scopes():
+                return ['new_scope']
+
+        self.assertEqual(_load_structures_import_scopes(Owner), ['new_scope'])
+
+    def test_falls_back_to_get_esi_scopes(self):
+        class Owner:
+            @staticmethod
+            def get_esi_scopes():
+                return ['old_scope']
+
+        self.assertEqual(_load_structures_import_scopes(Owner), ['old_scope'])
+
+
 # from unittest.mock import patch
 
 # from django.test import TestCase, RequestFactory

--- a/charlink/tests/test_app_imports.py
+++ b/charlink/tests/test_app_imports.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -9,6 +10,7 @@ from allianceauth.tests.auth_utils import AuthUtils
 from app_utils.testdata_factories import UserMainFactory
 
 from charlink.app_imports import import_apps, get_duplicated_apps, get_failed_to_import, get_no_import
+from charlink.app_imports.utils import AppImport
 from charlink.imports.corptools import _corp_perms
 from charlink.models import AppSettings
 
@@ -100,6 +102,62 @@ class TestImportApps(TestCase):
     def test_get_duplicated_apps_imports_apps(self, mock_import_module):
         get_duplicated_apps()
         self.assertTrue(mock_import_module.called)
+
+    @patch('charlink.app_imports.get_hooks', return_value=[])
+    @patch('charlink.app_imports.import_module')
+    def test_missing_default_import_is_reported_as_no_import(self, mock_import_module, _):
+        mock_import_module.side_effect = ModuleNotFoundError(
+            "No module named 'charlink.imports.fakeapp'",
+            name='charlink.imports.fakeapp',
+        )
+
+        with patch('charlink.app_imports.settings.INSTALLED_APPS', ['fakeapp']):
+            imported_apps = import_apps()
+
+        self.assertEqual(imported_apps, {})
+        self.assertEqual(get_failed_to_import(), {})
+        self.assertEqual(get_no_import(), ['fakeapp'])
+
+    @patch('charlink.app_imports.get_hooks', return_value=[])
+    @patch('charlink.app_imports.import_module')
+    def test_default_import_missing_dependency_is_reported_as_failed(self, mock_import_module, _):
+        mock_import_module.side_effect = ModuleNotFoundError(
+            "No module named 'missing_dependency'",
+            name='missing_dependency',
+        )
+
+        with patch('charlink.app_imports.settings.INSTALLED_APPS', ['brokenapp']):
+            imported_apps = import_apps()
+
+        self.assertEqual(imported_apps, {})
+        self.assertIn('brokenapp', get_failed_to_import())
+        self.assertEqual(get_no_import(), [])
+
+    @patch('charlink.app_imports.get_hooks', return_value=[])
+    @patch('charlink.app_imports.import_module')
+    def test_default_import_generic_exception_is_reported_as_failed(self, mock_import_module, _):
+        mock_import_module.side_effect = AttributeError('broken optional import')
+
+        with patch('charlink.app_imports.settings.INSTALLED_APPS', ['brokenapp']):
+            imported_apps = import_apps()
+
+        self.assertEqual(imported_apps, {})
+        self.assertIn('brokenapp', get_failed_to_import())
+        self.assertEqual(get_no_import(), [])
+
+    @patch('charlink.app_imports.get_hooks', return_value=[])
+    @patch('charlink.app_imports.import_module')
+    def test_default_import_validation_failure_is_reported_as_failed(self, mock_import_module, _):
+        mock_import_module.return_value = SimpleNamespace(
+            app_import=AppImport('invalidapp', [])
+        )
+
+        with patch('charlink.app_imports.settings.INSTALLED_APPS', ['invalidapp']):
+            imported_apps = import_apps()
+
+        self.assertEqual(imported_apps, {})
+        self.assertIn('invalidapp', get_failed_to_import())
+        self.assertEqual(get_no_import(), [])
 
 
 @patch('charlink.app_imports._imported', False)


### PR DESCRIPTION
## Summary

This improves CharLink compatibility with Alliance Auth 5-era optional app APIs.

Some optional apps changed their ESI scope helper names during AA5 migration, for example from `get_esi_scopes()` to `esi_scopes()`. CharLink now resolves those helpers by capability detection so integrations remain compatible with older and newer app releases.

This also hardens default optional import discovery: missing CharLink integrations are still reported as unavailable, while broken optional integration imports are tracked as failed imports instead of bubbling up and breaking dashboard/login rendering.

## Changes

- Support both old and new ESI scope helper names for Structures.
- Support both old and new ESI scope helper names for Member Audit.
- Distinguish missing built-in default integration modules from missing transitive dependencies.
- Record default import validation and generic import failures in failed imports.
- Add focused tests for old/new helper names and default import failure classification.
- Document the AA4/AA5 optional integration behavior in the README.

## Testing

- `python3 -m py_compile charlink/app_imports/__init__.py charlink/imports/memberaudit.py charlink/imports/structures.py charlink/tests/imports/test_memberaudit.py charlink/tests/imports/test_structures.py charlink/tests/test_app_imports.py`
- `git diff --check`
- `USE_MYSQL=0 AA_REDIS=127.0.0.1:6379 uv run --python 3.11 --with tox tox -e py311`

The tox run passed locally with SQLite and a temporary local Redis instance.